### PR TITLE
feat: scan reader with storage client

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ pip install ng_nx
 
 ### Reading Data from NebulaGraph
 
+> With GraphD Client
+
 ```python
 from ng_nx import NebulaReader
 from ng_nx.utils import NebulaGraphConfig
@@ -79,6 +81,28 @@ reader = NebulaReader(
     edges=["follow", "serve"],
     properties=[["degree"], ["start_year", "end_year"]],
     nebula_config=config, limit=10000)
+
+g = reader.read()
+```
+
+> With Storage Client, this requires ng_nx being run within NebulaGraph Network or expose the metad and storaged to it, with same host and port being registered in NebulaGraph(`SHOW HOSTS META;` and `SHOW HOSTS;`).
+
+```python
+from ng_nx import NebulaScanReader
+from ng_nx.utils import NebulaGraphConfig
+
+# Here, we need to be able to resolve the metad and storaged hosts, where they are the same with `SHOW HOSTS META;` and `SHOW HOSTS;`
+
+config = NebulaGraphConfig(
+    space="demo_basketballplayer",
+    graphd_hosts="graphd0:9669",
+    metad_hosts="metad0:9559"
+)
+
+reader = NebulaScanReader(
+    edges=["follow", "serve"],
+    properties=[["degree"], ["start_year", "end_year"]],
+    nebula_config=config, limit=10000, with_rank=True)
 
 g = reader.read()
 ```
@@ -253,11 +277,11 @@ g = reader.read(query)
 
 NG-NX provides three types of readers to fetch data from NebulaGraph:
 
-1. `NebulaReader`: Reads a graph from NebulaGraph based on specified edges and properties, returning a NetworkX graph. It uses the MATCH clause internally to fetch data from NebulaGraph.
+1. `NebulaReader`(**Load from Edge and Properties via MATCH**): Reads a graph from NebulaGraph based on specified edges and properties, returning a NetworkX graph. It uses the MATCH clause internally to fetch data from NebulaGraph.
 
-2. `NebulaQueryReader`: Executes a custom NebulaGraph query and constructs a NetworkX graph from the result. This reader is particularly useful when you need to perform complex queries or have specific data retrieval requirements.
+2. `NebulaQueryReader`(**Construct from Any Query**): Executes a custom NebulaGraph query and constructs a NetworkX graph from the result. This reader is particularly useful when you need to perform complex queries or have specific data retrieval requirements.
 
-3. `NebulaScanReader` (Coming soon): Will read graph data from NebulaGraph using a configuration similar to `NebulaReader`, but it will bypass the MATCH clause and utilize the SCAN interface with the Storage Client for potentially improved performance on large datasets.
+3. `NebulaScanReader`(**Better for LARGE datasets**): Will read graph data from NebulaGraph using a configuration similar to `NebulaReader`, but it will bypass the MATCH clause and utilize the SCAN interface with the Storage Client for potentially improved performance on large datasets. Note that this reader requires the NebulaGraph cluster to configure the metad and storaged accessible from the ng_nx.
 
 Each reader is designed to cater to different use cases, providing flexibility in how you interact with and retrieve data from NebulaGraph for analysis with NetworkX.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -17,6 +17,7 @@ config = NebulaGraphConfig(**config_dict)
 reader = NebulaReader(
     edges=["follow", "serve"],
     properties=[["degree"], ["start_year", "end_year"]],
+    with_rank=True, # this enable the multi-graph, and the edge_key is "__rank__" from NebulaGraph rank(edge)
     nebula_config=config, limit=100)
 
 g = reader.read()
@@ -27,6 +28,55 @@ pr = nx.pagerank(
     max_iter=100,
     tol=1e-06,
     weight='degree')
+```
+
+
+## NebulaQueryReader
+
+The `NebulaQueryReader` allows you to execute any NebulaGraph query and construct a NetworkX graph from the result.
+
+```python
+from ng_nx import NebulaQueryReader
+from ng_nx.utils import NebulaGraphConfig
+
+config = NebulaGraphConfig(
+    space="demo_basketballplayer",
+    graphd_hosts="127.0.0.1:9669",
+    metad_hosts="127.0.0.1:9559"
+)
+
+reader = NebulaQueryReader(
+    query="MATCH p=(v:player{name:'Tim Duncan'})-[e:follow*1..3]->(v2) RETURN p",
+    nebula_config=config,
+    limit=10000,
+    with_rank=True,
+)
+
+g = reader.read()
+```
+
+## NebulaScanReader
+
+The `NebulaScanReader` allows you to scan all vertexes and edges in NebulaGraph, and construct a NetworkX graph from the result.
+
+```python
+from ng_nx import NebulaScanReader
+from ng_nx.utils import NebulaGraphConfig
+
+# Here, we need to be able to resolve the metad and storaged hosts, where they are the same with `SHOW HOSTS META;` and `SHOW HOSTS;`
+
+config = NebulaGraphConfig(
+    space="demo_basketballplayer",
+    graphd_hosts="graphd0:9669",
+    metad_hosts="metad0:9559"
+)
+
+reader = NebulaScanReader(
+    edges=["follow", "serve"],
+    properties=[["degree"], ["start_year", "end_year"]],
+    nebula_config=config, limit=10000, with_rank=True)
+
+g = reader.read()
 ```
 
 ## NebulaWriter

--- a/ng_nx/scan_reader.py
+++ b/ng_nx/scan_reader.py
@@ -1,16 +1,73 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2023 The NebulaGraph Authors. All rights reserved.
 
-from typing import Dict
+from typing import Dict, List
 
 import networkx as nx
-import pandas as pd
-from nebula3.Config import Config
-from nebula3.data.ResultSet import ResultSet
-from nebula3.gclient.net import ConnectionPool
+from nebula3.mclient import MetaCache, HostAddr
+from nebula3.sclient.GraphStorageClient import GraphStorageClient
 
-from ng_nx.utils import NebulaGraphConfig
+from ng_nx.utils import NebulaGraphConfig, cast
 
 
 class NebulaScanReader:
-    pass
+    def __init__(
+        self,
+        edges: List[str],
+        properties: List[List[str]],
+        nebula_config: NebulaGraphConfig,
+        limit: int,
+        with_rank: bool = False,  # this enable the multi-graph, and the edge_key is "__rank__"
+    ):
+        self.edges = edges
+        self.properties = properties
+        self.limit = limit
+        self.space = nebula_config.space
+
+        metad_hosts = nebula_config.metad_hosts.split(",")
+        metad_host_list = [
+            (host.split(":")[0], int(host.split(":")[1])) for host in metad_hosts
+        ]
+        self.meta_cache = MetaCache(metad_host_list, 50000)
+        self.graph_storage_client = GraphStorageClient(self.meta_cache)
+
+        self.with_rank = with_rank
+
+        assert len(edges) > 0 and len(edges) == len(
+            properties
+        ), "edges and properties should have the same length"
+
+    def read(self) -> nx.MultiDiGraph:
+        g = nx.MultiDiGraph()
+
+        for i, edge in enumerate(self.edges):
+            edge_properties = self.properties[i]
+            resp = self.graph_storage_client.scan_edge(
+                space_name=self.space, edge_name=edge
+            )
+            edge_count = 0
+            while resp.has_next() and edge_count < self.limit:
+                result = resp.next()
+                for edge_data in result.as_relationships():
+                    src = cast(edge_data.start_vertex_id())
+                    dst = cast(edge_data.end_vertex_id())
+                    props = {}
+                    for prop in edge_properties:
+                        props[prop] = cast(edge_data.properties().get(prop))
+                    if self.with_rank:
+                        rank = edge_data.ranking()
+                        props["__rank__"] = rank
+                        g.add_edge(src, dst, key=rank, **props)
+                    else:
+                        g.add_edge(src, dst, **props)
+                    edge_count += 1
+                    if edge_count >= self.limit:
+                        break
+
+        return g
+
+    def release(self):
+        self.graph_storage_client.close()
+
+    def __del__(self):
+        self.release()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ filter_files = true
 
 [project]
 name = "ng_nx"
-version = "0.2.2"
+version = "0.2.3"
 description = "NebulaGraph NetowrkX Adaptor"
 authors = [
     {name = "Wey Gu", email = "weyl.gu@gmail.com"},


### PR DESCRIPTION
```python
from ng_nx import NebulaScanReader
from ng_nx.utils import NebulaGraphConfig

# Here, we need to be able to resolve the metad and storaged hosts, where they are the same with `SHOW HOSTS META;` and `SHOW HOSTS;`

config = NebulaGraphConfig(
    space="demo_basketballplayer",
    graphd_hosts="graphd0:9669",
    metad_hosts="metad0:9559"
)

reader = NebulaScanReader(
    edges=["follow", "serve"],
    properties=[["degree"], ["start_year", "end_year"]],
    nebula_config=config, limit=10000, with_rank=True)

g = reader.read()
```